### PR TITLE
1 Removed Modes.  Release Ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ import VueGlow from 'vue-glow';
   I am GLOWING bright red!
 </VueGlow>
 
-<VueGlow :color="#3535ff" mode="hex">
+<VueGlow :color="#3535ff">
   I am using hex colors!
 </VueGlow>
 
-<VueGlow :color="{ r: 33, g: 66, b: 99 }" mode="rgb">
+<VueGlow :color="{ r: 33, g: 66, b: 99 }">
   I am using rbg colors!
+</VueGlow>
+
+<VueGlow :color="{ h: 176, s: 88, l: 44 }">
+  I am using Hsv colors!
 </VueGlow>
 ```
 
@@ -40,7 +44,6 @@ import VueGlow from 'vue-glow';
 | Prop        | Effect        | Default |
 | ------------|---------------| ------- |
 | color | Changes the color of the glow.  Can either be a color name, hex, a RGB dict, HSL dict, or HSV dict. | "red" |
-| mode | Changes the mode of the color input. Can be 'name', 'hex', 'rgb', or 'hsl'. | "name" |
 | elevation  | Changes the elevation effect of the glow.  Can be a number between 0-24. | 12 |
 | intensity | Customize the intensity of the glow. Can be a number between 0-4. | 1 |
 | intense | Doubles the intensity of the glow. | false |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-glow",
-  "version": "0.3.3",
+  "version": "1.4.0",
   "description": "A performant wrapper component to give dynamic glow effects in Vue ",
   "author": "awtkns",
   "keywords": [

--- a/src/VueGlow.vue
+++ b/src/VueGlow.vue
@@ -13,7 +13,6 @@ export default {
   props: {
     rounded: { default: 4 },
     color: { default: 'red' },
-    mode: { type: String, default: 'name' },
     elevation: { default: 12 },
     intense: { type: Boolean, default: false },
     intensity: { type: Number, default: 1 },
@@ -66,8 +65,7 @@ export default {
         elevation: this.elevation,
         hsl: this.hsl,
         important: this.important,
-        intensity: this.intense ? this.intensity * 2 : this.intensity,
-        mode: this.mode
+        intensity: this.intense ? this.intensity * 2 : this.intensity
       };
 
       return `${glowStyle(conf)}`
@@ -85,7 +83,7 @@ export default {
       this.hsl.h = (this.reversed ? (this.hsl.h -= 1):(this.hsl.h += 1)) % 360
     },
     colorChanged() {
-      this.hsl = colorToHSL(this.color, this.mode)
+      this.hsl = colorToHSL(this.color)
     }
   },
   beforeDestroy() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,20 @@
 import { colorNames } from './contants,js'
 
-export function colorToHSL(color, mode) {
-  switch (mode.toLowerCase()) {
+
+export function colorToHSL(color) {
+  if (!color) return undefined
+
+  let mode = ''
+  if (typeof color === 'string' && color.length) mode = color.charAt(0) === '#' ? 'hex' : 'name'
+  else if (typeof color === 'object') {
+    if (color.r !== undefined && color.g !== undefined && color.b !== undefined) mode = 'rgb'
+    else if (color.h !== undefined && color.s !== undefined) {
+      if (color.v !== undefined) mode = 'hsv'
+      else if (color.l !== undefined) mode = 'hsl'
+    }
+  }
+
+  switch (mode) {
     case 'hsl':
       return color;
     case 'hsv':
@@ -20,6 +33,7 @@ export function colorToHSL(color, mode) {
 
 
 function hsvToHsl({h, s, v}) {
+  s = s / 100; v = v / 100;
   const l = (2 - s) * v / 2;
 
   if (l !== 0) {


### PR DESCRIPTION
Removed the modes prop from props.  Vueglow now uses type introspection to determine whether to use rgb colors, hex colors, named colors ect....

# New
```js
<VueGlow color="red" intense >
  I am GLOWING bright red!
</VueGlow>

<VueGlow :color="#3535ff">
  I am using hex colors!
</VueGlow>
```

# Old
```js
<VueGlow color="red" intense mode="rgb">
  I am GLOWING bright red!
</VueGlow>

<VueGlow :color="#3535ff" mode="hex">
  I am using hex colors!
</VueGlow>
```
